### PR TITLE
Add .env example file in order to avoid running the project without i…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+
+NODE_ENV=development
+HOST=0.0.0.0
+PORT=3000
+COMUNI_JSON_FILE=comuni.json

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Here are URL where it takes the data:
 
 ### env variable
 
-you need to use these env variables
+you need to use these env variables.
+Feel free to change it in order to strict your envoirement rules.
 
 ```
 NODE_ENV=development
@@ -24,8 +25,8 @@ HOST=0.0.0.0
 PORT=3000
 COMUNI_JSON_FILE=comuni.json
 ```
-
-you can put these in a .env files or use it in CLI
+The project has on its dependencies *dotenv*, so
+you can use the .env.example file provided (remove the .example notation) or use it in CLI using *export command* or whatever you like.
 
 ### Update comuni data
 
@@ -39,16 +40,12 @@ you can put these in a .env files or use it in CLI
 
 - /comuni
 ```
-curl -X GET \
-  http://127.0.0.1:3009/comuni \
-  -H 'Content-Type: application/json'
+curl -X GET http://127.0.0.1:3000/comuni -H 'Content-Type: application/json'
 ```
 
 - /comuni/:comune
 ```
-curl -X GET \
-  http://127.0.0.1:3009/comuni/brescia \
-  -H 'Content-Type: application/json'
+curl -X GET http://127.0.0.1:3000/comuni/brescia -H 'Content-Type: application/json'
 ```
 
 # Docker


### PR DESCRIPTION
The project has on its dependencies dotenv, so why not provide an .env file by example?
Then i fix documentation cause your env example and curl example reporting 2 differt ports, 3000 and 3009.